### PR TITLE
Remove punishment role on unban, move punishment role settings into it's own sub command

### DIFF
--- a/src/classes/Config.ts
+++ b/src/classes/Config.ts
@@ -167,13 +167,6 @@ export class Config {
         emoji: '📕',
         label: 'Punishments',
       },
-      {
-        type: 'BUTTON',
-        style: 'SECONDARY',
-        customId: 'CONFIG_SET_ROLE',
-        emoji: '📛',
-        label: 'Punishment role',
-      },
     ]);
   }
 }

--- a/src/classes/Config.ts
+++ b/src/classes/Config.ts
@@ -102,7 +102,7 @@ export class Config {
       },
       {
         name: 'Log Channel',
-        value: `Channel: <#${logchan}>\n> A text channel where all bot logs are sent to. Please use \`/config logchan\` to change this`,
+        value: `Channel: <#${logchan}>\n> A text channel where all bot logs are sent to. Please use \`/config logs logchan\` to change this`,
       },
       {
         name: 'Unban',

--- a/src/classes/Config.ts
+++ b/src/classes/Config.ts
@@ -108,7 +108,7 @@ export class Config {
         name: 'Unban',
         value: `Status: \`${
           punishments.unban ? 'Enabled' : 'Disabled'
-        }\`\n> This will automatically unban a user when appealed, if they are banned via Warden`,
+        }\`\n> This will automatically unban a user when appealed, if they are banned via Warden. Also removes their punishment role if one is set.`,
       },
       {
         name: 'Global Scan',

--- a/src/commands/admin/appeal.ts
+++ b/src/commands/admin/appeal.ts
@@ -121,6 +121,7 @@ export default class AppealCommand extends SlashCommand {
           enabled: true,
         },
       },
+      select: { punishments: true, id: true, name: true },
     });
 
     let unbanned = 0;
@@ -131,6 +132,10 @@ export default class AppealCommand extends SlashCommand {
       client.guilds
         .fetch(guild.id)
         .then((g) => {
+          if (guild.punishments.roleId) {
+            const member = g.members.cache.find((member) => member.id === id);
+            member.roles.remove(guild.punishments.roleId);
+          }
           g.bans
             .fetch(id)
             .then((b) => {

--- a/src/commands/user/config.ts
+++ b/src/commands/user/config.ts
@@ -13,6 +13,11 @@ export default class ConfigCommand extends SlashCommand {
       options: [
         {
           type: 'SUB_COMMAND',
+          name: 'settings',
+          description: 'All bot settings',
+        },
+        {
+          type: 'SUB_COMMAND',
           name: 'logs',
           description: 'Log Channel Settings',
           options: [
@@ -150,10 +155,13 @@ export default class ConfigCommand extends SlashCommand {
           });
           return false;
         });
-    } else {
+    }
+
+    if (!rolePunish && !logchan) {
       await interaction.reply({ ephemeral: true, content: 'Sent configuration menu' });
       client.config.sendConfigMenu(interaction, interaction.guild.id);
     }
+
     return true;
   }
 }

--- a/src/events/configMenu.ts
+++ b/src/events/configMenu.ts
@@ -31,62 +31,6 @@ export default async function (client: Bot, interaction: ButtonInteraction): Pro
       }
       break;
     }
-    case 'SET_ROLE': {
-      const guildRoles: MessageSelectOptionData[] = [
-        { label: 'Disable', value: 'no_role', emoji: '❌' },
-        ...interaction.guild.roles.cache.map((role) => ({ label: role.name, value: role.id })),
-      ].filter((role) => role.label !== '@everyone'); // Exclude the default @everyone role
-      try {
-        await interaction.reply({
-          embeds: [
-            {
-              author: {
-                name: 'Punishment role',
-                iconURL: client.user.defaultAvatarURL,
-              },
-              description: 'Set a role for blacklisted users to receive upon joining',
-              color: Colours.GREEN,
-            },
-          ],
-          components: [
-            new MessageActionRow().addComponents([
-              {
-                type: 'SELECT_MENU',
-                customId: 'PUNISHMENT_ROLE',
-                placeholder: 'Nothing selected',
-                options: guildRoles,
-              },
-            ]),
-          ],
-        });
-
-        await interaction.channel
-          .awaitMessageComponent({
-            filter: (i) => i.user.id === interaction.user.id,
-            componentType: 'SELECT_MENU',
-            time: 60000,
-          })
-          .then(async (i) => {
-            const roleId = i.values[0];
-            const message = await i.channel.messages.fetch(i.message.id);
-            message.delete();
-            updateGuildPunishment(client, message.guild.id, { roleId: roleId === 'no_role' ? null : roleId });
-          })
-          .catch((err) => console.log(err));
-      } catch (e) {
-        console.log(e);
-        await interaction.reply({
-          embeds: [
-            {
-              description:
-                'This interaction has failed, please make sure you have channels, if you do report this in the Warden Discord',
-              color: Colours.RED,
-            },
-          ],
-        });
-      }
-      break;
-    }
     case 'TOGGLE_UNBAN': {
       if (guild.punishments.unban) {
         await updateGuildPunishment(client, message.guild.id, { unban: false });


### PR DESCRIPTION
Removes the user's assigned punishment role upon appeal if unban is set to true,

Moved the punishment role settings into a separate sub command, along with logs settings and the config embed call since apparently you can't call the original command if you use sub commands.