### PR TITLE
(feat): Add multiforcecheck command and implement delay to avoid rate…

### DIFF
--- a/src/commands/admin/multiforcecheck.ts
+++ b/src/commands/admin/multiforcecheck.ts
@@ -1,0 +1,44 @@
+import { ApplicationCommandOptionType } from 'discord.js';
+import { Command } from '../../structures/Command';
+import actionUsersGlobal from '../../utils/actioning/actionUsersGlobal';
+import db from '../../utils/database';
+import { sendError, sendSuccess } from '../../utils/messages';
+
+export default new Command({
+    name: 'multiforcecheck',
+    description: 'Globally check users',
+    main: true,
+    defaultMemberPermissions: 'Administrator',
+    options: [
+        {
+            type: ApplicationCommandOptionType.String,
+            name: 'users',
+            description: 'Comma-separated list of user IDs',
+            required: true,
+        },
+    ],
+    run: async ({ interaction, client }) => {
+        const idsString = interaction.options.getString('users');
+        if (!idsString) return sendError(interaction, 'Invalid user IDs provided');
+
+        const ids = idsString.split(',').map(id => id.trim());
+        if (ids.length === 0) return sendError(interaction, 'No valid user IDs provided');
+
+        for (const id of ids) {
+            const user = await db.getUser(id);
+            if (!user) return sendError(interaction, `User with ID ${id} not found in database`);
+            if (user.status === 'WHITELISTED')
+                return sendError(interaction, `You cannot action a whitelisted user with ID ${id}`);
+            if (user.status === 'APPEALED')
+                return sendError(interaction, `You cannot action an appealed user with ID ${id}`);
+            if (user.type === 'BOT')
+                return sendError(interaction, `You cannot action a bot user with ID ${id}`);
+        }
+
+        sendSuccess(interaction, 'Requested force check on all shards');
+        await actionUsersGlobal(client, ids);
+        sendSuccess(interaction, 'Force check successfully completed');
+
+        return false;
+    },
+});

--- a/src/utils/actioning/actionGlobal.ts
+++ b/src/utils/actioning/actionGlobal.ts
@@ -20,6 +20,8 @@ export default async function (c: Client) {
 
     const result = await c.shard.broadcastEval(
         async (client, { dbGuilds }) => {
+            const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
             const output: any[] = [];
 
             await client.guilds.fetch();
@@ -40,12 +42,14 @@ export default async function (c: Client) {
                     const member = guild.members.cache.at(a);
                     if (!member) continue;
 
-                    client.emit('guildMemberAdd', member)
+                    client.emit('guildMemberAdd', member);
 
                     output.push({
                         labels: { action: 'globalscan', guildId: guild.id },
                         message: `Emitted guildMemberAdd for ${member.id}`,
                     });
+
+                    await delay(1000);
                 }
             }
 


### PR DESCRIPTION
(feat): Add multiforcecheck command and implement delay to avoid rate limiting

- Added multiforcecheck command to globally check multiple users by accepting a comma-separated list of user IDs.
- Implemented delay in forcecheck and globalscan to avoid hitting Discord's rate limits.
- Updated actionUsersGlobal function to handle multiple user IDs efficiently.