### PR TITLE
(fix): Ensure managed roles are included when returning original roles

### DIFF
--- a/src/utils/actioning/actionAppeal.ts
+++ b/src/utils/actioning/actionAppeal.ts
@@ -80,7 +80,11 @@ export default async function (c: Client, id: string): Promise<boolean> {
                     try {
                         const guild: Guild = await client.guilds.fetch(element.guild);
                         const member: GuildMember = await guild.members.fetch(element.id);
-                        await member.roles.set(element.roles.split(','));
+                        const managedRoles = member.roles.cache.filter(role => role.managed).map(role => role.id);
+                        const returnRoles = element.roles.split(',');
+                        const uniqueRoles = new Set([...returnRoles, ...managedRoles]);
+
+                        await member.roles.set([...uniqueRoles]);
 
                         output.push({
                             labels: { action: 'actionAppeal', guildId: guild.id },


### PR DESCRIPTION
- Added logic to merge managed roles with the roles specified in element.roles.
- Used a Set to ensure unique role IDs and prevent errors due to duplicate roles.
- This ensures that managed roles are preserved when setting the member's roles.