### PR TITLE
Feature/User action by server type and custom ban settings

### DIFF
--- a/src/commands/dev/forceexport.ts
+++ b/src/commands/dev/forceexport.ts
@@ -33,7 +33,7 @@ export default new Command({
         const settings = await db.getGuild({ id: id }, { punishments: true });
         if (!settings) return sendError(interaction, 'Unable to find guild in the database');
 
-        const punishRole = settings.punishments?.roleId;
+        const punishRole = settings?.punishments?.roleId;
         if (!punishRole) return sendError(interaction, 'Invalid punish role set');
 
         await db.removeAllBans({ guild: id });

--- a/src/commands/dev/forceguildscan.ts
+++ b/src/commands/dev/forceguildscan.ts
@@ -36,7 +36,7 @@ export default new Command({
         });
         if (!settings) return sendError(interaction, 'Unable to find guild in the database');
 
-        const punishRole = settings.punishments?.roleId;
+        const punishRole = settings?.punishments?.roleId;
         if (!punishRole) return sendError(interaction, 'Invalid punish role set');
 
         const result = await client.shard.broadcastEval(

--- a/src/commands/dev/scanappealed.ts
+++ b/src/commands/dev/scanappealed.ts
@@ -30,6 +30,7 @@ export default new Command({
 
         const settings = await db.getGuild({ id: id }, { punishments: true });
         if (!settings) return sendError(interaction, 'Unable to find guild in the database');
+        if (settings.punishments?.banAppeal) return sendError(interaction, 'This guild has ban appeals enabled');
 
         const result = await client.shard.broadcastEval(
             async (c, { guildId }) => {

--- a/src/commands/user/export.ts
+++ b/src/commands/user/export.ts
@@ -15,7 +15,7 @@ export default new Command({
 
         if (!settings) return sendError(interaction, 'Unable to find guild in the database');
 
-        const punishRole = settings.punishments?.roleId;
+        const punishRole = settings?.punishments?.roleId;
         if (!punishRole) return sendError(interaction, 'Invalid punish role set');
 
         await interaction.guild.bans.fetch().catch(e => {

--- a/src/commands/user/scanusers.ts
+++ b/src/commands/user/scanusers.ts
@@ -1,88 +1,88 @@
-import { TextChannel } from 'discord.js';
-import { Colours } from '../../@types/Colours';
-import { Command } from '../../structures/Command';
-import actionUser from '../../utils/actioning/actionUser';
-import logger from '../../utils/logger';
-import { sendError, sendSuccess } from '../../utils/messages';
-import sendEmbed from '../../utils/messages/sendEmbed';
-import db from '../../utils/database';
+import { TextChannel } from 'discord.js'
+import { Colours } from '../../@types/Colours'
+import { Command } from '../../structures/Command'
+import actionUser from '../../utils/actioning/actionUser'
+import logger from '../../utils/logger'
+import { sendError, sendSuccess } from '../../utils/messages'
+import sendEmbed from '../../utils/messages/sendEmbed'
+import db from '../../utils/database'
 
-const cooldowns = new Map<string, number>();
-const COOLDOWN_TIME = 30 * 60 * 1000;
+const cooldowns = new Map<string, number>()
+const COOLDOWN_TIME = 30 * 60 * 1000
 
 export default new Command({
     name: 'scanusers',
     description: 'Initiates a guild scan',
     defaultMemberPermissions: 'Administrator',
     run: async ({ interaction, client }) => {
-        if (!interaction.guild) return sendError(interaction, 'Must be used in a guild');
+        if (!interaction.guild) return sendError(interaction, 'Must be used in a guild')
 
-        const guildId = interaction.guild.id;
-        const now = Date.now();
-        const cooldown = cooldowns.get(guildId);
+        const guildId = interaction.guild.id
+        const now = Date.now()
+        const cooldown = cooldowns.get(guildId)
 
         if (cooldown && now < cooldown) {
-            const remainingTime = Math.ceil((cooldown - now) / 1000 / 60);
-            return sendError(interaction, `You can use this command again in ${remainingTime} minutes`);
+            const remainingTime = Math.ceil((cooldown - now) / 1000 / 60)
+            return sendError(interaction, `You can use this command again in ${remainingTime} minutes`)
         }
 
-        cooldowns.set(guildId, now + COOLDOWN_TIME);
+        cooldowns.set(guildId, now + COOLDOWN_TIME)
 
         const guild = await client.guilds.fetch(interaction.guild.id).catch(e => {
             logger.error({
                 labels: { command: 'scanusers', userId: interaction?.user?.id, guildId: interaction?.guild?.id },
                 message: e instanceof Error ? e.message : JSON.stringify(e),
-            });
-            return undefined;
-        });
+            })
+            return undefined
+        })
 
-        if (!guild) return sendError(interaction, 'Failed to fetch guild');
+        if (!guild) return sendError(interaction, 'Failed to fetch guild')
 
         const settings = await db.getGuild(
             { id: interaction.guild.id },
             { punishments: true, logChannel: true }
-        );
-        if (!settings) return sendError(interaction, 'Unable to find guild in database');
-        if (!settings.punishments?.enabled) return sendError(interaction, 'Punishments are not enabled');
+        )
+        if (!settings) return sendError(interaction, 'Unable to find guild in database')
+        if (!settings?.punishments?.enabled) return sendError(interaction, 'Punishments are not enabled')
 
         await guild.members.fetch().then(async members => {
-            const memberMap = members.filter(x => !x.user.bot).map(x => x.id);
+            const memberMap = members.filter(x => !x.user.bot).map(x => x.id)
             const users = await db.getManyUsers({
                 id: { in: memberMap },
-                status: { in: ['BLACKLISTED', 'PERM_BLACKLISTED'] },
-            });
+                status: { in: settings?.punishments?.banAppeal ? ['APPEALED', 'BLACKLISTED', 'PERM_BLACKLISTED'] : ['BLACKLISTED', 'PERM_BLACKLISTED'] },
+            })
 
             if (users.length === 0)
-                return sendSuccess(interaction, 'Scanning has complete, no users blacklisted');
+                return sendSuccess(interaction, 'Scanning has complete, no users blacklisted')
 
-            if (!settings.punishments) return sendError(interaction, 'No punishments set for this guild');
-            if (!settings.logChannel) return sendError(interaction, 'Must have a log channel set');
+            if (!settings?.punishments) return sendError(interaction, 'No punishments set for this guild')
+            if (!settings.logChannel) return sendError(interaction, 'Must have a log channel set')
 
-            sendSuccess(interaction, 'Scanning..\n> This may take a while due to Discords rate limit');
+            sendSuccess(interaction, 'Scanning..\n> This may take a while due to Discords rate limit')
 
-            let actioned = 0;
+            let actioned = 0
 
             for (let index = 0; index < users.length; index++) {
-                const user = users[index];
+                const user = users[index]
                 const result = await actionUser(
                     client,
                     guild,
                     settings.logChannel,
-                    settings.punishments,
+                    settings?.punishments,
                     user
                 ).catch(e => {
                     logger.error({
                         labels: { command: 'scanusers', userId: interaction?.user?.id, guildId: interaction?.guild?.id },
                         message: e instanceof Error ? e.message : JSON.stringify(e),
-                    });
-                });
-                if (result) actioned += 1;
+                    })
+                })
+                if (result) actioned += 1
             }
 
             logger.info({
                 labels: { command: 'scanusers', userId: interaction?.user?.id, guildId: interaction?.guild?.id },
                 message: `${interaction?.user?.tag} (${interaction?.user?.id}) has initiated a scan with a total of ${memberMap.length} members, ${actioned} blacklisted users have been actioned accordingly`,
-            });
+            })
 
             sendEmbed({
                 channel: interaction.channel as TextChannel,
@@ -90,18 +90,18 @@ export default new Command({
                     description: `Scanning has completed, \`${actioned}\` are blacklisted and have been actioned accordingly`,
                     color: Colours.GREEN,
                 },
-            });
+            })
 
-            return true;
+            return true
         }).catch(e => {
             logger.error({
                 labels: { command: 'scanusers', userId: interaction?.user?.id, guildId: interaction?.guild?.id },
                 message: e instanceof Error ? e.message : JSON.stringify(e),
-            });
+            })
 
-            return sendError(interaction, 'Failed to fetch members');
-        });
-        
-        return false;
+            return sendError(interaction, 'Failed to fetch members')
+        })
+
+        return false
     },
-});
+})

--- a/src/events/guildCreate.ts
+++ b/src/events/guildCreate.ts
@@ -1,18 +1,18 @@
-import { ChannelType, TextChannel } from 'discord.js';
-import { Colours } from '../@types/Colours';
-import { Event } from '../structures/Event';
-import logger from '../utils/logger';
-import sendEmbed from '../utils/messages/sendEmbed';
-import db from '../utils/database';
+import { ChannelType, TextChannel } from 'discord.js'
+import { Colours } from '../@types/Colours'
+import { Event } from '../structures/Event'
+import logger from '../utils/logger'
+import sendEmbed from '../utils/messages/sendEmbed'
+import db from '../utils/database'
 
 export default new Event('guildCreate', async guild => {
     try {
-        await guild.channels.fetch();
+        await guild.channels.fetch()
         const channel = guild.channels.cache
             .filter(chan => chan?.type === ChannelType.GuildText)
-            .first() as TextChannel;
+            .first() as TextChannel
 
-        if (!channel) return false;
+        if (!channel) return false
 
         await db.createGuild({
             id: guild.id,
@@ -21,12 +21,12 @@ export default new Event('guildCreate', async guild => {
             punishments: {
                 create: {},
             },
-        });
+        })
 
         logger.info({
             labels: { event: 'guildCreate', guildId: guild.id },
             message: `Warden joined a new guild: ${guild.name}`,
-        });
+        })
 
         await sendEmbed({
             channel,
@@ -36,17 +36,17 @@ export default new Event('guildCreate', async guild => {
                       You can call me Warden or 5 Warden (V Warden).
                       \nThank you for inviting me to your Discord Server!
                       I'm trying to make the CFX Community a better place.
-                      \nMake sure to check my configuration settings by using \`/config\` command!
+                      \nMake sure to check my configuration settings by using \`/config info\` command!
                       I also need to have the permissions to kick and ban members, with a role higher than them!
                       \nIf you want to contribute to the project, use the Official Discord: <https://discord.gg/MVNZR73Ghf>`,
                 color: Colours.GREEN,
             },
-        });
+        })
     } catch (e) {
         logger.error({
             labels: { event: 'guildCreate', guildId: guild.id },
             message: e instanceof Error ? e.message : JSON.stringify(e),
-        });
+        })
     }
-    return true;
-});
+    return true
+})

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -1,32 +1,32 @@
-import { ChannelType, GuildMember, TextChannel } from 'discord.js';
-import { client } from '../bot';
-import { Event } from '../structures/Event';
-import actionUser from '../utils/actioning/actionUser';
-import db from '../utils/database';
-import logger from '../utils/logger';
+import { ChannelType, GuildMember, TextChannel } from 'discord.js'
+import { client } from '../bot'
+import { Event } from '../structures/Event'
+import actionUser from '../utils/actioning/actionUser'
+import db from '../utils/database'
+import logger from '../utils/logger'
 
 export default new Event('guildMemberAdd', async (member: GuildMember) => {
-    if (member.user.bot) return false;
+    if (member.user.bot) return false
 
-    const { guild } = member;
-    const settings = await db.getGuild({ id: guild.id }, { punishments: true, logChannel: true });
+    const { guild } = member
+    const settings = await db.getGuild({ id: guild.id }, { punishments: true, logChannel: true })
 
     if (!settings) {
         try {
             logger.error({
                 labels: { event: 'guildMemberAdd', guildId: guild.id },
                 message: 'Guild has no settings, creating'
-            });
-            
-            await guild.channels.fetch();
+            })
+
+            await guild.channels.fetch()
             const channel = guild.channels.cache
                 .filter(chan => chan?.type === ChannelType.GuildText)
-                .first() as TextChannel;
+                .first() as TextChannel
             if (!channel)
                 return logger.error({
                     labels: { event: 'guildMemberAdd', guildId: guild.id },
                     message: 'Guild has no text channels, cancelling creation',
-                });
+                })
 
             await db.createGuild({
                 id: guild.id,
@@ -35,33 +35,33 @@ export default new Event('guildMemberAdd', async (member: GuildMember) => {
                 punishments: {
                     create: {},
                 },
-            });
+            })
         } catch (e) {
             logger.error({
                 labels: { event: 'guildMemberAdd', guildId: guild.id },
                 message: e instanceof Error ? e.message : JSON.stringify(e),
-            });
+            })
         }
-        return false;
+        return false
     }
 
-    if (!settings.logChannel || !settings.punishments)
+    if (!settings.logChannel || !settings?.punishments)
         return logger.info({
             labels: { event: 'guildMemberAdd', guildId: guild.id },
             message: 'Guild has no settings or a log channel set',
-        });
+        })
 
-    if (!settings.punishments?.enabled)
+    if (!settings?.punishments?.enabled)
         return logger.info({
             labels: { event: 'guildMemberAdd', guildId: guild.id },
             message: 'Guild has punishments disabled',
-        });
+        })
 
-    const user = await db.getUser(member.id);
-    if (!user) return false;
-    if (user.status === 'BLACKLISTED' || user.status === 'PERM_BLACKLISTED') {
-        await actionUser(client, guild, settings.logChannel, settings.punishments, user);
+    const user = await db.getUser(member.id)
+    if (!user) return false
+    if (settings?.punishments?.banAppeal ? user.status === 'BLACKLISTED' || user.status === 'PERM_BLACKLISTED' || user.status === 'APPEALED' : user.status === 'BLACKLISTED' || user.status === 'PERM_BLACKLISTED') {
+        await actionUser(client, guild, settings.logChannel, settings?.punishments, user)
     }
 
-    return true;
-});
+    return true
+})

--- a/src/utils/actioning/actionAppeal.ts
+++ b/src/utils/actioning/actionAppeal.ts
@@ -1,7 +1,8 @@
-import db from '../database';
-import { Client, Guild, GuildBan, GuildMember } from 'discord.js';
-import logger from '../logger';
-import { Bans, Roles } from '@prisma/client';
+import db from '../database'
+import { Client, Guild, GuildBan, GuildMember } from 'discord.js'
+import logger from '../logger'
+import { Bans, Roles } from '@prisma/client'
+import { convertServersTypeToUsersType } from './utils'
 
 /**
  * Removes roles/bans for user on appeal
@@ -13,117 +14,195 @@ export default async function (c: Client, id: string): Promise<boolean> {
         logger.warn({
             labels: { action: 'actionAppeal', userId: id },
             message: 'No shards online, unable to action appeal',
-        });
-        return false;
+        })
+        return false
     }
 
     const bansPromise = db.getAllBans({
         id,
         Guild: { punishments: { unban: true, enabled: true } },
-    });
+    })
 
-    const rolesPromise = db.getAllRoles({ id });
+    const rolesPromise = db.getAllRoles({ id })
 
-    const [bans, roles] = await Promise.all([bansPromise, rolesPromise]);
+    const [bans, roles] = await Promise.all([bansPromise, rolesPromise])
+
+    const servers = await Promise.all(bans.map(async (ban) => {
+        const settings = await db.getGuild({ id: ban.guild }, { punishments: true })
+        return { guild: ban.guild, settings }
+    }))
+
+    let allUserTypes = [] as string[]
+    for (let index = 0; index < servers.length; index++) {
+        const element = servers[index]
+
+        if (!element.settings?.punishments?.unbanOther ||
+            !element.settings?.punishments?.unbanLeaker ||
+            !element.settings?.punishments?.unbanCheater ||
+            !element.settings?.punishments?.unbanSupporter ||
+            !element.settings?.punishments?.unbanOwner) {
+            const allImportsPromise = db.getAllImports(id)
+            const [allImports] = await Promise.all([allImportsPromise])
+            const getUser = await db.getUser(id)
+            allUserTypes = getUser ? [getUser.type] : []
+
+            if (allImports.length > 0) {
+                let BadServersType: string[] = []
+                if (allImports.length > 0) {
+                    allImports.map((x) => {
+                        if (x?.BadServer && x?.BadServer?.type) BadServersType.push(x.BadServer.type)
+                    })
+                }
+
+                const serversTypeToUsersType = convertServersTypeToUsersType(BadServersType)
+
+                allUserTypes = [...allUserTypes, ...serversTypeToUsersType]
+            }
+        }
+    }
 
     const result = await c.shard.broadcastEval(
-        async (client, { id, bans, roles }) => {
-            const output = [];
+        async (client, { id, bans, roles, servers, allUserTypes }) => {
+            const output = []
 
             await client.guilds.fetch().catch(e => {
                 output.push({
                     labels: { action: 'actionAppeal' },
                     message: e instanceof Error ? e.message : JSON.stringify(e),
-                });
-            });
+                })
+            })
 
-            const guilds = client.guilds.cache.map(x => x.id);
-            const guildBans: Bans[] = bans.filter(x => guilds.some(a => a === x.guild));
-            const guildRoles: Roles[] = roles.filter(x => guilds.some(a => a === x.guild));
+            const guilds = client.guilds.cache.map(x => x.id)
+            const guildBans: Bans[] = bans.filter(x => guilds.some(a => a === x.guild))
+            const guildRoles: Roles[] = roles.filter(x => guilds.some(a => a === x.guild))
 
             if (!guildBans && !guildRoles) {
                 output.push({
                     labels: { action: 'actionAppeal', userId: id },
                     message: `No bans or roles found for ${id} on this shard`,
-                });
+                })
 
-                return output;
+                return output
             }
 
             if (guildBans.length > 0) {
                 for (let index = 0; index < guildBans.length; index++) {
-                    const element = guildBans[index];
+                    const element = guildBans[index]
                     try {
-                        const guild: Guild = await client.guilds.fetch(element.guild);
-                        const ban: GuildBan = await guild.bans.fetch({ user: element.id, force: true });
+                        const guild: Guild = await client.guilds.fetch(element.guild)
+                        const settings = servers.find(x => x.guild === element.guild)?.settings
 
-                        if (!ban.reason?.includes('Warden - User Type')) continue;
+                        if (!settings?.punishments?.unbanOther && allUserTypes.includes('OTHER')) {
+                            output.push({
+                                labels: { action: 'actionAppeal', userId: element.id, guildId: guild.id },
+                                message: `User ${element.id} is type Other and is disallowed from being unbanned in ${guild.name} (${guild.id})`,
+                            })
+                            continue
+                        }
+                        if (!settings?.punishments?.unbanLeaker && allUserTypes.includes('LEAKER')) {
+                            output.push({
+                                labels: { action: 'actionAppeal', userId: element.id, guildId: guild.id },
+                                message: `User ${element.id} is type Leaker and is disallowed from being unbanned in ${guild.name} (${guild.id})`,
+                            })
+                            continue
+                        }
+                        if (!settings?.punishments?.unbanCheater && allUserTypes.includes('CHEATER')) {
+                            output.push({
+                                labels: { action: 'actionAppeal', userId: element.id, guildId: guild.id },
+                                message: `User ${element.id} is type Cheater and is disallowed from being unbanned in ${guild.name} (${guild.id})`,
+                            })
+                            continue
+                        }
+                        if (!settings?.punishments?.unbanSupporter && allUserTypes.includes('SUPPORTER')) {
+                            output.push({
+                                labels: { action: 'actionAppeal', userId: element.id, guildId: guild.id },
+                                message: `User ${element.id} is type Supporter and is disallowed from being unbanned in ${guild.name} (${guild.id})`,
+                            })
+                            continue
+                        }
+                        if (!settings?.punishments?.unbanOwner && allUserTypes.includes('OWNER')) {
+                            output.push({
+                                labels: { action: 'actionAppeal', userId: element.id, guildId: guild.id },
+                                message: `User ${element.id} is type Owner and is disallowed from being unbanned in ${guild.name} (${guild.id})`,
+                            })
+                            continue
+                        }
 
-                        await guild.bans.remove(element.id);
+                        const ban: GuildBan = await guild.bans.fetch({ user: element.id, force: true })
+
+                        if (!ban.reason?.includes('Warden - User Type')) continue
+
+                        await guild.bans.remove(element.id)
 
                         output.push({
                             labels: { action: 'actionAppeal', guildId: guild.id },
-                            message: `Unbanned ${element.id}`,
-                        });
+                            message: `Unbanned ${element.id} from ${guild.name} (${guild.id})`,
+                        })
                     } catch (e) {
                         output.push({
-                            labels: { action: 'actionAppeal' },
+                            labels: { action: 'actionAppeal', userId: id, guildId: element.guild },
                             message: e instanceof Error ? e.message : JSON.stringify(e),
-                        });
+                        })
                     }
                 }
             } else {
                 output.push({
                     labels: { action: 'actionAppeal', userId: id },
-                    message: 'No bans found in database',
-                });
+                    message: `No bans found in database for user ${id}`,
+                })
             }
 
             if (guildRoles.length > 0) {
                 for (let index = 0; index < guildRoles.length; index++) {
-                    const element = guildRoles[index];
+                    const element = guildRoles[index]
                     try {
-                        const guild: Guild = await client.guilds.fetch(element.guild);
-                        const member: GuildMember = await guild.members.fetch(element.id);
-                        const managedRoles = member.roles.cache.filter(role => role.managed).map(role => role.id);
-                        const returnRoles = element.roles.split(',');
-                        const uniqueRoles = new Set([...returnRoles, ...managedRoles]);
+                        const guild: Guild = await client.guilds.fetch(element.guild)
+                        const member: GuildMember = await guild.members.fetch(element.id)
+                        const managedRoles = member.roles.cache.filter(role => role.managed).map(role => role.id)
+                        const returnRoles = element.roles.split(',')
+                        const uniqueRoles = new Set([...returnRoles, ...managedRoles])
 
-                        await member.roles.set([...uniqueRoles]);
+                        await member.roles.set([...uniqueRoles])
 
                         output.push({
-                            labels: { action: 'actionAppeal', guildId: guild.id },
-                            message: `Set roles for ${member.id} - ${element.roles}`,
-                        });
+                            labels: { action: 'actionAppeal', userId: id, guildId: guild.id },
+                            message: `Give roles back to ${id} in ${guild.name} (${guild.id})`,
+                        })
                     } catch (e) {
                         output.push({
-                            labels: { action: 'actionAppeal' },
+                            labels: { action: 'actionAppeal', userId: id, guildId: element.guild },
                             message: e instanceof Error ? e.message : JSON.stringify(e),
-                        });
+                        })
                     }
                 }
             } else {
                 output.push({
                     labels: { action: 'actionAppeal', userId: id },
-                    message: 'No roles found in database',
-                });
+                    message: `No roles found in database for user ${id}`,
+                })
             }
 
-            return output;
+            return output
         },
-        { context: { id: id, bans: bans, roles: roles } }
-    );
+        { context: { id: id, bans: bans, roles: roles, servers: servers, allUserTypes: allUserTypes } }
+    )
 
-    for (let index = 0; index < result.length; index++) {
-        for (let i = 0; i < result.length; i++) {
-            logger.info(result[index][i]);
+    if (result.length > 0) {
+        for (let index = 0; index < result.length; index++) {
+            const element = result[index]
+            if (element.length > 0) {
+                for (let index = 0; index < element.length; index++) {
+                    const log = element[index]
+                    logger.info(log)
+                }
+            }
         }
     }
 
-    const removeBansPromise = db.removeAllBans({ id });
-    const removeRolesPromise = db.removeAllRoles({ id });
+    const removeBansPromise = db.removeAllBans({ id })
+    const removeRolesPromise = db.removeAllRoles({ id })
 
-    await Promise.all([removeBansPromise, removeRolesPromise]);
+    await Promise.all([removeBansPromise, removeRolesPromise])
 
-    return true;
+    return true
 }

--- a/src/utils/actioning/actionUser.ts
+++ b/src/utils/actioning/actionUser.ts
@@ -1,13 +1,15 @@
-import { Client, Guild, TextChannel, PermissionsBitField } from 'discord.js';
-import { Colours } from '../../@types/Colours';
-import { generateErrorID } from '../../utils/misc';
-import { getPunishment } from './utils';
-import { Punish, Punishments, Users } from '@prisma/client';
-import actionAppeal from './actionAppeal';
-import db from '../database';
-import logger, { logException } from '../logger';
-import queueActionSend from '../queues/queueActionSend';
-import sendEmbed from '../messages/sendEmbed';
+import { all } from 'axios'
+import { Client, Guild, TextChannel, PermissionsBitField } from 'discord.js'
+import { Colours } from '../../@types/Colours'
+import { generateErrorID } from '../../utils/misc'
+import { getPunishment, convertServersTypeToUsersType } from './utils'
+import { Punish, Punishments, Users } from '@prisma/client'
+import { UserType } from '@prisma/client'
+import actionAppeal from './actionAppeal'
+import db from '../database'
+import logger, { logException } from '../logger'
+import queueActionSend from '../queues/queueActionSend'
+import sendEmbed from '../messages/sendEmbed'
 
 /**
  * Actions a user on a specific guild
@@ -23,67 +25,140 @@ export default async function actionUser(
     punishments: Punishments,
     user: Users
 ) {
-    const member = await guild.members.fetch(user.id);
-    if (!member) return false;
-    if (member.user.bot) return false;
+    const member = await guild.members.fetch(user.id)
+    if (!member) return false
+    if (member.user.bot) return false
 
-    const importsPromise = db.getImports(user.id);
-    const allImportsPromise = db.getAllImports(user.id);
-    const appealedImportsPromise = db.getAppealedImports(user.id);
+    const importsPromise = db.getImports(user.id)
+    const allImportsPromise = db.getAllImports(user.id)
+    const appealedImportsPromise = db.getAppealedImports(user.id)
 
-    const [imports, allImports, appealedImports] = await Promise.all([importsPromise, allImportsPromise, appealedImportsPromise]);
+    const [imports, allImports, appealedImports] = await Promise.all([importsPromise, allImportsPromise, appealedImportsPromise])
 
     if (allImports.length === 0) {
-        await actionAppeal(client, user.id);
-        await db.deleteUser(user.id);
-        return false;
+        await actionAppeal(client, user.id)
+        await db.deleteUser(user.id)
+        return false
     }
 
-    if (user.status === 'BLACKLISTED' && user.reason === 'Unspecified' && allImports.length === appealedImports.length) {
-        await db.updateUser(user.id, { status: 'APPEALED', appeals: { increment: 1 } });
-        await actionAppeal(client, user.id);
-        return false;
+    if (!punishments.banAppeal) {
+        if (user.status === 'BLACKLISTED' && user.reason === 'Unspecified' && allImports.length === appealedImports.length) {
+            await db.updateUser(user.id, { status: 'APPEALED', appeals: { increment: 1 } })
+            await actionAppeal(client, user.id)
+            return false
+        }
     }
 
-    let realCount = 0;
+    let realCount = 0
     try {
         if (imports.length === 1) {
-            const toParse = imports[0].roles;
+            const toParse = imports[0].roles
             if (toParse.includes('"servers":')) {
-                const parsed = JSON.parse(toParse);
-                const servers: string[] = parsed['servers'].split(';');
-                realCount = servers.length;
+                const parsed = JSON.parse(toParse)
+                const servers: string[] = parsed['servers'].split(';')
+                realCount = servers.length
             } else {
-                realCount = 1;
+                realCount = 1
             }
         } else {
-            realCount = imports.length;
+            realCount = imports.length
         }
     } catch (e) {
         logger.error({
             labels: { action: 'actionUser', userId: user.id, guildId: member.guild.id },
             message: e instanceof Error ? e.message : JSON.stringify(e),
-        });
-        return false;
+        })
+        return false
     }
 
-    const toDo: Punish = getPunishment(user.type, punishments);
+    let BadServersType: string[] = []
+    if (allImports.length > 0) {
+        allImports.map((x) => {
+            if (x?.BadServer && x?.BadServer?.type) BadServersType.push(x.BadServer.type)
+        })
+    }
 
-    let channel: TextChannel;
+    const serversTypeToUsersType = convertServersTypeToUsersType(BadServersType)
+
+    if (user.status === 'APPEALED' && punishments.banAppeal) {
+        /*
+        * Check if appealed user should be punished
+        * @param user - User
+        * @param punishments - Guild punishments
+        * @param BadServersType - Array of server types
+        * @returns boolean
+        */
+        const checkAppealedUser = (user: Users, punishments: Punishments, BadServersType: any[]): boolean => {
+            const shouldUnbanType = (type: UserType) => {
+                if (type === 'OTHER' && punishments.other === Punish.BAN && punishments.unbanOther === false) {
+                    return false
+                } else if (type === 'LEAKER' && punishments.leaker === Punish.BAN && punishments.unbanLeaker === false) {
+                    return false
+                } else if (type === 'CHEATER' && punishments.cheater === Punish.BAN && punishments.unbanCheater === false) {
+                    return false
+                } else if (type === 'SUPPORTER' && punishments.supporter === Punish.BAN && punishments.unbanSupporter === false) {
+                    return false
+                } else if (type === 'OWNER' && punishments.owner === Punish.BAN && punishments.unbanOwner === false) {
+                    return false
+                }
+                return true
+            }
+
+            // If global unban is enabled, check specific type unban settings
+            if (punishments.unban) {
+                // If any specific type unban setting is false, the user should be punished
+                if (!shouldUnbanType(user.type)) {
+                    return true
+                }
+
+                for (const type of BadServersType) {
+                    if (!shouldUnbanType(type as UserType)) {
+                        return true
+                    }
+                }
+
+                // If all specific type unban settings are true, the user should not be punished
+                return false
+            }
+
+            // If global unban is not enabled, check specific type unban settings
+            if (!shouldUnbanType(user.type)) {
+                return true
+            }
+
+            for (const type of BadServersType) {
+                if (!shouldUnbanType(type as UserType)) {
+                    return true
+                }
+            }
+
+            // If none of the conditions for unbanning are met, the user should be punished
+            return false
+        }
+
+        const shouldPunish = checkAppealedUser(user, punishments, serversTypeToUsersType)
+        if (!shouldPunish) {
+            return false
+        }
+    }
+
+    const toDo: any = getPunishment(user.type, punishments, serversTypeToUsersType)
+
+    let channel: TextChannel
     try {
-        channel = (await guild.channels.fetch(logChannel ?? '')) as TextChannel;
+        channel = (await guild.channels.fetch(logChannel ?? '')) as TextChannel
     } catch {
-        return false;
+        return false
     }
 
-    if (!channel) return false;
+    if (!channel) return false
 
     await queueActionSend(user.id, member.guild.id, toDo).catch(e => {
-        const errorId = generateErrorID();
+        const errorId = generateErrorID()
         logger.error({
             labels: { action: 'actionUser', guildId: member.guild.id },
             message: e instanceof Error ? e.message : JSON.stringify(e),
-        });
+        })
 
         sendEmbed({
             channel,
@@ -91,14 +166,14 @@ export default async function actionUser(
                 description: `\`🔴\` An unexpected error has occured\n> Error ID: \`${errorId}\`\n> Please report this in the [Warden Discord](https://discord.gg/MVNZR73Ghf)`,
                 color: Colours.RED,
             },
-        });
-    });
+        })
+    })
 
     if (toDo === 'WARN') {
         logger.info({
             labels: { action: 'actionUser', userId: user.id, guildId: member.guild.id },
             message: `${member.user.username} (${user.id}) was seen in ${member.guild.name} (${member.guild.id}) and has been queued for a direct message`,
-        });
+        })
 
         sendEmbed({
             channel,
@@ -106,36 +181,36 @@ export default async function actionUser(
                 description: `:warning: User <@${member.id}> has been seen in ${realCount == 0 ? 1 : realCount} bad discord servers.\n**User Status**: ${user.status.toLowerCase()} / **User Type**: ${user.type.toLowerCase()}`,
                 color: Colours.GREEN,
             },
-        });
+        })
 
-        return true;
+        return true
     } else if (toDo === 'ROLE') {
         try {
-            if (!punishments.roleId) throw new Error('Invalid role id set');
-            const oldRoles = member.roles.cache.map(x => x.id).join(',');
+            if (!punishments.roleId) throw new Error('Invalid role id set')
+            const oldRoles = member.roles.cache.map(x => x.id).join(',')
 
-            const hasBlacklistedAlready = member.roles.cache.find(x => x.id === punishments.roleId);
-            if (hasBlacklistedAlready) return false;
+            const hasBlacklistedAlready = member.roles.cache.find(x => x.id === punishments.roleId)
+            if (hasBlacklistedAlready) return false
 
             // Get managed roles (linked roles)
-            const managedRoles = member.roles.cache.filter(role => role.managed).map(role => role.id);
+            const managedRoles = member.roles.cache.filter(role => role.managed).map(role => role.id)
 
             // Combine the new role with the managed roles
-            const newRoles = [...managedRoles, punishments.roleId];
+            const newRoles = [...managedRoles, punishments.roleId]
 
             // Set the new roles
-            await member.roles.set(newRoles);
+            await member.roles.set(newRoles)
 
             await db.createArchiveRole({
                 id: member.id,
                 roles: oldRoles,
                 Guild: { connect: { id: punishments.id } },
-            });
+            })
 
             logger.info({
                 labels: { action: 'actionUser', guildId: member.guild.id },
                 message: `${member.user.username} (${user.id}) was seen in ${member.guild.name} (${member.guild.id}) has been given the role ${punishments.roleId} and has been queued for a direct message`,
-            });
+            })
 
             sendEmbed({
                 channel,
@@ -143,15 +218,15 @@ export default async function actionUser(
                     description: `:shield: User <@${member.id}> has been punished with a ROLE.\nThey have been seen in ${realCount == 0 ? 1 : realCount} bad discord servers.\n**User Status**: ${user.status.toLowerCase()}`,
                     color: Colours.GREEN,
                 },
-            });
+            })
 
-            return true;
+            return true
         } catch (e: any) {
-            const errorId = await logException(null, e);
-            const botRole = await guild?.members?.me?.roles?.highest.position;
-            const memRole = await member?.roles?.highest.position;
-            if (typeof botRole === 'undefined' || typeof memRole === 'undefined' || typeof punishments.roleId === 'undefined') return;
-            const botCanMan = await guild?.members?.me?.permissions?.has(PermissionsBitField?.Flags.ManageRoles);
+            const errorId = await logException(null, e)
+            const botRole = await guild?.members?.me?.roles?.highest.position
+            const memRole = await member?.roles?.highest.position
+            if (typeof botRole === 'undefined' || typeof memRole === 'undefined' || typeof punishments.roleId === 'undefined') return
+            const botCanMan = await guild?.members?.me?.permissions?.has(PermissionsBitField?.Flags.ManageRoles)
             if (typeof botCanMan === 'boolean' && typeof botRole == 'number' && typeof memRole == 'number') {
                 sendEmbed({
                     channel,
@@ -159,7 +234,7 @@ export default async function actionUser(
                         description: `I tried to remove this user's role and set them to \`${punishments.roleId}\`, however I encountered an error. \n> Debug: ${botRole} - ${memRole} - ${botCanMan}\n> Error ID: ${errorId}`,
                         color: Colours.RED,
                     },
-                });
+                })
             } else {
                 sendEmbed({
                     channel,
@@ -167,28 +242,28 @@ export default async function actionUser(
                         description: `I tried to remove this user's role and set them to \`${punishments.roleId}\`, however I encountered an error. \n> Error ID: ${errorId}`,
                         color: Colours.RED,
                     },
-                });
+                })
             }
-            return false;
+            return false
         }
     } else if (toDo === 'KICK' || toDo === 'BAN') {
         logger.info({
             labels: { action: 'actionUser', guildId: member.guild.id },
             message: `${member.user.username} (${user.id}) was seen in ${member.guild.name} (${member.guild.id}) and has been queued for a ${toDo} and direct message`,
-        });
+        })
 
         if (punishments.roleId) {
-            const hasBlacklistedAlready = member.roles.cache.find(x => x.id === punishments.roleId);
-            if (hasBlacklistedAlready) return false;
+            const hasBlacklistedAlready = member.roles.cache.find(x => x.id === punishments.roleId)
+            if (hasBlacklistedAlready) return false
 
             // Get managed roles (linked roles)
-            const managedRoles = member.roles.cache.filter(role => role.managed).map(role => role.id);
+            const managedRoles = member.roles.cache.filter(role => role.managed).map(role => role.id)
 
             // Combine the new role with the managed roles
-            const newRoles = [...managedRoles, punishments.roleId];
+            const newRoles = [...managedRoles, punishments.roleId]
 
             // Set the new roles
-            await member.roles.set(newRoles);
+            await member.roles.set(newRoles)
 
             sendEmbed({
                 channel,
@@ -196,9 +271,9 @@ export default async function actionUser(
                     description: `:shield: User <@${member.id}> has been seen in ${realCount == 0 ? 1 : realCount} bad discord servers and has been queued for a ${toDo}.\n**User Status**: ${user.status.toLowerCase()}`,
                     color: Colours.YELLOW,
                 },
-            });
+            })
 
-            return true;
+            return true
         } else {
             sendEmbed({
                 channel,
@@ -206,11 +281,11 @@ export default async function actionUser(
                     description: `:shield: User <@${member.id}> has been seen in ${realCount == 0 ? 1 : realCount} bad discord servers and has been queued for a ${toDo}.\n**User Status**: ${user.status.toLowerCase()}\n\nPlease configure a punishment role through Warden to prevent interactions until the action is completed.`,
                     color: Colours.YELLOW,
                 },
-            });
+            })
 
-            return true;
+            return true
         }
     }
 
-    return true;
+    return true
 }

--- a/src/utils/actioning/utils.ts
+++ b/src/utils/actioning/utils.ts
@@ -1,24 +1,55 @@
-import { Punish, Punishments, UserType } from '@prisma/client';
+import { Punish, Punishments, UserType } from '@prisma/client'
 
-export function getPunishment(type: UserType, punishments: Punishments): Punish {
-    let toDo: Punish = 'WARN';
-    switch (type) {
-        case UserType.OWNER:
-            toDo = punishments.owner;
-            break;
-        case UserType.SUPPORTER:
-            toDo = punishments.supporter;
-            break;
-        case UserType.LEAKER:
-            toDo = punishments.leaker;
-            break;
-        case UserType.CHEATER:
-            toDo = punishments.cheater;
-            break;
-        case UserType.OTHER:
-            toDo = punishments.other;
-            break;
+export function getPunishment(userType: UserType, punishments: Punishments, BadServersType: string[]): Punish {
+    const punishmentOrder: Punish[] = ['WARN', 'ROLE', 'KICK', 'BAN']
+
+    // Get the punishment for the userType
+    let toDo: Punish = 'WARN'
+    if (userType === UserType.OWNER) {
+        toDo = punishments.owner
+    } else if (userType === UserType.SUPPORTER) {
+        toDo = punishments.supporter
+    } else if (userType === UserType.LEAKER) {
+        toDo = punishments.leaker
+    } else if (userType === UserType.CHEATER) {
+        toDo = punishments.cheater
+    } else if (userType === UserType.OTHER) {
+        toDo = punishments.other
     }
 
-    return toDo;
+    // Get the highest punishment from BadServersType
+    for (const type of BadServersType) {
+        let punishment: Punish = 'WARN'
+        if (type === 'OWNER') {
+            punishment = punishments.owner
+        } else if (type === 'SUPPORTER') {
+            punishment = punishments.supporter
+        } else if (type === 'LEAKER') {
+            punishment = punishments.leaker
+        } else if (type === 'CHEATER') {
+            punishment = punishments.cheater
+        } else if (type === 'OTHER') {
+            punishment = punishments.other
+        }
+
+        // Compare and get the highest punishment
+        if (punishmentOrder.indexOf(punishment) > punishmentOrder.indexOf(toDo)) {
+            toDo = punishment
+        }
+    }
+
+    return toDo
+}
+
+export function convertServersTypeToUsersType(BadServersType: string[]): UserType[] {
+    return BadServersType.map(type => {
+        if (type === 'CHEATING') {
+            return 'CHEATER'
+        } else if (type === 'RESELLING' || type === 'ADVERTISING' || type === 'OTHER') {
+            return 'OTHER'
+        } else if (type === 'LEAKING') {
+            return 'LEAKER'
+        }
+        return type as UserType
+    })
 }

--- a/src/utils/queues/queueActionReceive.ts
+++ b/src/utils/queues/queueActionReceive.ts
@@ -123,7 +123,6 @@ async function actionUser(client: Client, id: string, guildId: string, toDo: str
     if (!member) return false
     const user = await db.getUser(id)
     if (!user) return false
-    if (user?.status === 'APPEALED') return false
     if (user?.status === 'WHITELISTED') return false
     if (member.user.bot) return false
 
@@ -157,7 +156,7 @@ async function actionUser(client: Client, id: string, guildId: string, toDo: str
     const settings = await db.getGuild({ id: guildId }, { logChannel: true, punishments: true })
     if (!settings?.logChannel) return false
     const logChannel = settings.logChannel
-    const punishments = settings.punishments
+    const punishments = settings?.punishments
 
     let channel: TextChannel
     try {


### PR DESCRIPTION
- **Refactored User Action System**  
  New: Previously, punishments were only applied based on the user type. Now, punishments consider both user and server types. The punishment hierarchy is as follows:  
  `WARN` > `ROLE` > `KICK` > `BAN`.  

  **Example:**  
  If a user is of type `SUPPORTER` (punishment: `KICK`) and also of server type `CHEATER` (punishment: `BAN`), the **highest-level punishment** (`BAN`) will be applied.  

- **Configure Bans**  
  **Update:**  
  - **Automatic Unban** has been moved from settings to `/config bans`.  
  **New:**  
  - **Ban Appealed Users**, Ban users even if their appeal has been accepted, unless **Automatic Unban** is enabled. This setting still respects exceptions configured in `/config unbans`.  

- **Configure Unbans**  
  **New:**  
  - You can now specify rules to prevent unbans for certain types. To enable these rules, turn on **Automatic Unban** in `/config bans` and set the punishment to `BAN` in `/config punishments`.  

- **Configure View Update**  
  The `/config view` command has been removed, use `/config info` instead to see configuration details.
